### PR TITLE
Fixes

### DIFF
--- a/guide/installing-henkaku.md
+++ b/guide/installing-henkaku.md
@@ -28,6 +28,8 @@ This will allow us to access the Vita’s internal memory and install homebrew w
 2. Select HENkaku Settings
 3. Check **Enable Unsafe Homebrew**
 
+<p class="notice">If you are looking to install HENkaku Enso for 3.65, stop here and proceed <a href="/more/updating-to-henkaku-enso-3.65/">here</a>.</p>
+
 ## Installing Homebrew
 Now we’ve got that out the way, we can start to install some homebrew applications to put on our Home Menu
 
@@ -44,7 +46,5 @@ Now we’ve got that out the way, we can start to install some homebrew applicat
 	- Make sure you still have unsafe homebrew enabled
 
 You can now use VitaShell as your main file browser, and use Vita Homebrew Browser to download whatever homebrew you want. Keep in mind that Unsafe Homebrew must be enabled to run Vita Homebrew Browser.
-
-<p class="notice">If you are looking to install HENkaku Enso for 3.65, stop here and proceed <a href="/more/updating-to-henkaku-enso-3.65/">here</a>.</p>
 
 <center><a href="/guide/installing-henkaku-enso"><button class="btn btn--light-outline">Installing HENkaku Ensō</button></a></center>

--- a/more/updating-to-henkaku-enso-3.65.md
+++ b/more/updating-to-henkaku-enso-3.65.md
@@ -17,7 +17,7 @@ You can now update your 3.60 HENkaku enabled PS Vita to 3.65, while keeping HENk
 
 If you do not follow this guide correctly, you could lose homebrew access, with **no way to get it back!**
 
-Only follow this guide if you want to use PSN or install games which require a firmware version higher than 3.61!
+Only follow this guide if you want to legitimately activate your Vita for official PSN content or install games which require a firmware version higher than 3.61!
 
 Please follow all steps in this guide carefully. I will not be responsible to anything that happens to your device when using this.
 
@@ -69,8 +69,8 @@ Do not reboot, turn off, or let your PS Vita run out of charge while following t
 3. Open `ux0`
 3. Go down to the `VitaShell` directory
 3. Press **Triangle** and then select "Delete"
-3. Press **Select**
 3. Delete the `patch/VITASHELL/` directory
+3. Press **Select**
 4. Open your FTP client on your computer
 5. Type in the IP Address and Port shown on your Vita
 6. Navigate to `ux0:data` on the FTP Client
@@ -91,11 +91,11 @@ Do not reboot, turn off, or let your PS Vita run out of charge while following t
 15. Press **Triangle** and then select "Paste"
   - The 'PSP2UPDAT.PUP' file should be there
 16. Open `ux0:tai/config.txt`
-17. Add a hashtag before each user-made plugin
+17. Add a hashtag before (disable) each plugin you may have installed
 	- e.g. NoNpDrm, ReNpDrm, ReStore, DownloadEnabler, gamesd (SD2Vita), etc.
 	- e.g. turn `ux0:tai/gamesd.skrpx` to `#ux0:tai/gamesd.skrpx`
 18. Open`ur0:tai/config.txt`
-19. Add a hashtag before each user-made plugin
+19. Add a hashtag before (disable) each plugin
 20. Exit MolecularShell
 
 ### Backing up VitaShell


### PR DESCRIPTION
It seems like you can access PSN and store even on 3.60 (tested personally myself, I'm just not sure if it was thanks to henkaku or/and edited DNS)
The only clear thing I was barren from, was activating my account/vita. 

Also, reworded that "user-made" thing.. Because I swear, for a good deal of minutes I understood "user-mode". 
"That you may have installed" also kinda implies that if you haven't done anything, you should already be good with this step. 

And last but not least, I moved the 3.65 warning above. 
I mean: if I'm installing henkaku for the first time, and I want to go straight to 3.65.. What's the point of the points below?
And continuing on this line of thought, I think you could make a big standalone "cleaning" section in the 3.65 instructions, to be explicitly be made optional for "total newcomers" - rather than having information conflated with other "core" steps. But I guess like this is quite big rework, so better if you think to it yourself. 
EDIT: also, I wasn't sure how you'd have liked to point out [offline update to 3.60](http://wololo.net/2016/08/09/manually-update-ps-vita-firmware-3-60/) instructions